### PR TITLE
Feature/gh pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,28 @@
+name: Deploy MkDocs site
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - rc1
+      - feature/gh-pages
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: pip install mkdocs mkdocs-material mkdocstrings-python
+
+    - name: Deploy to GitHub Pages
+      run: mkdocs gh-deploy --force

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,60 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/cuemsutils/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
 # Specify filepatterns you want git to ignore.
 __pycache__
 .vscode
+
+*.pyc
+*.ipynb
+.python-version
+.pytest_cache
+
+dist/
+
+## DEV files ##
+*.log
+*.log.*
+*.log-*
+nohup.out
+*.pid
+.coverage*
+
+dev/local/
+site/

--- a/CuemsDBModel.py
+++ b/CuemsDBModel.py
@@ -8,12 +8,12 @@ database = SqliteDatabase(None, pragmas={
 
 
 # TODO: discuss this; WAL mode is faster  but creates 3 files instead of 1, does not need synchonous=2 to mantain database integrity
-""" database = SqliteDatabase(None, pragmas={
-    'journal_mode': 'wal',
-    'cache_size': -1 * 4000,  # 4MB
-    'foreign_keys': 1,
-    'ignore_check_constraints': 0,
-    'synchronous': 1}) """
+# database = SqliteDatabase(None, pragmas={
+#     'journal_mode': 'wal',
+#     'cache_size': -1 * 4000,  # 4MB
+#     'foreign_keys': 1,
+#     'ignore_check_constraints': 0,
+#     'synchronous': 1})
 
 
 class CuemsBaseModel(Model):

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,13 @@
+# API Documentation
+
+This API is still in development and may change without notice.
+
+::: CuemsErrors
+::: CuemsDBMedia
+::: CuemsUpload
+::: CuemsUtils
+::: CuemsWsUser
+::: CuemsWsServer
+::: CuemsDBModel
+::: CuemsProjectManager
+::: CuemsDBProject

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# cuems-editor
+Central editor and frontend-backend elements for the CueMS system
+
+It handles the UI inteactions and the data storage of the project.
+
+[![PyPI - Version](https://img.shields.io/pypi/v/cuemseditor.svg)](https://pypi.org/project/cuemseditor)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cuemseditor.svg)](https://pypi.org/project/cuemseditor)
+
+
+## Installation
+
+```console
+pip install cuemseditor
+```
+
+## Release notes
+Please refer to the repository for [release notes](https://github.com/stagesoft/cuems-editor?tab=readme-ov-file#release-notes).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: cuemsutils
+repo_url: https://github.com/cuems/cuems-utils
+theme:
+  name: material
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: cuemsutils
-repo_url: https://github.com/cuems/cuems-utils
+site_name: Cuems Editor - FormitGo frontend and backend
+repo_url: https://github.com/cuems/cuems_editor
 theme:
   name: material
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Cuems Editor - FormitGo frontend and backend
-repo_url: https://github.com/cuems/cuems_editor
+repo_url: https://github.com/cuems/cuems-editor
 theme:
   name: material
 


### PR DESCRIPTION
Included Actions to auto deploy documentation automatically as Github Pages and deploy a Python Packages to PyPI when a release is created.

**NOTE**: If a package structure is implemented `gh-pages.yml` file must be edited in its last line:

`run: mkdocs gh-deploy --force` must become `run: PYTHONPATH=src mkdocs gh-deploy --force`